### PR TITLE
feat: add sorting by expense total

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 A minimal, GitHub-ready React + TypeScript + Vite + Tailwind project with the full interactive demo page.
 
+## Features
+
+- Track trips and expenses
+- Sort trips by start date, destination, or expense total
+
 ## Quickstart
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -116,6 +116,20 @@ function Row({ label, children }: { label: string; children: React.ReactNode }) 
   );
 }
 
+export type SortKey = "start" | "dest" | "expense";
+
+export function sortTrips(trips: Trip[], expenses: Expense[], sortKey: SortKey) {
+  const sum = (id: string) =>
+    expenses
+      .filter((e) => e.tripId === id)
+      .reduce((a, b) => a + (isFinite(b.amount) ? b.amount : 0), 0);
+  return [...trips].sort((a, b) => {
+    if (sortKey === "start") return a.startDate.localeCompare(b.startDate);
+    if (sortKey === "dest") return a.destination.localeCompare(b.destination);
+    return sum(b.id) - sum(a.id);
+  });
+}
+
 const DemoSeed: AppState = {
   trips: [
     {
@@ -154,7 +168,7 @@ export default function App() {
   });
 
   const [filter, setFilter] = useState("");
-  const [sortKey, setSortKey] = useState<"start" | "dest">("start");
+  const [sortKey, setSortKey] = useState<SortKey>("start");
 
   const visibleTrips = useMemo(() => {
     const f = state.trips.filter(
@@ -162,8 +176,8 @@ export default function App() {
         t.destination.toLowerCase().includes(filter.toLowerCase()) ||
         t.purpose.toLowerCase().includes(filter.toLowerCase())
     );
-    return [...f].sort((a, b) => (sortKey === "start" ? a.startDate.localeCompare(b.startDate) : a.destination.localeCompare(b.destination)));
-  }, [state.trips, filter, sortKey]);
+    return sortTrips(f, state.expenses, sortKey);
+  }, [state.trips, state.expenses, filter, sortKey]);
 
   function addTrip() {
     const trip: Trip = {
@@ -258,6 +272,7 @@ export default function App() {
             <select className="border rounded-xl px-3 py-2" value={sortKey} onChange={(e) => setSortKey(e.target.value as any)}>
               <option value="start">Sort by start date</option>
               <option value="dest">Sort by destination</option>
+              <option value="expense">Sort by expanse height</option>
             </select>
             <div className="text-sm text-gray-500 flex items-center">{visibleTrips.length} trip(s)</div>
           </div>

--- a/src/sortTrips.test.ts
+++ b/src/sortTrips.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { sortTrips, SortKey } from "./App";
+
+describe("sortTrips", () => {
+  it("sorts by expense total", () => {
+    const trips = [
+      { id: "t1", startDate: "2025-01-01", destination: "A" },
+      { id: "t2", startDate: "2025-01-02", destination: "B" },
+    ];
+    const expenses = [
+      { id: "e1", tripId: "t1", date: "", category: "Other", amount: 10, currency: "EUR" },
+      { id: "e2", tripId: "t2", date: "", category: "Other", amount: 20, currency: "EUR" },
+    ];
+    const sorted = sortTrips(trips as any, expenses as any, "expense" as SortKey);
+    expect(sorted[0].id).toBe("t2");
+  });
+});


### PR DESCRIPTION
## Summary
- add sorting helper for trips
- allow sorting trips by expense total
- document new sorting option

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b0bd4012b8832daa251fc1dc90ddad