### PR TITLE
Gracefully handle missing customer and project fields

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import App from './App';
+import App, { matchesFilter } from './App';
 import { describe, it, expect } from 'vitest';
 
 describe('Trip fields', () => {
@@ -19,5 +19,25 @@ describe('Trip fields', () => {
 
     expect(customerInput.value).toBe('ACME');
     expect(projectInput.value).toBe('Launch');
+  });
+});
+
+describe('Trip filter', () => {
+  it('handles trips without customer or project', () => {
+    const trip = {
+      id: 't1',
+      origin: '',
+      destination: 'Paris',
+      startDate: '2025-01-01',
+      endDate: '2025-01-02',
+      purpose: '',
+      mileageKm: 0,
+      includeBreakfast: false,
+      includeLunch: false,
+      includeDinner: false,
+    } as any;
+
+    expect(matchesFilter(trip, 'par')).toBe(true);
+    expect(matchesFilter(trip, 'acme')).toBe(false);
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -148,6 +148,16 @@ const DemoSeed: AppState = {
   ],
 };
 
+export function matchesFilter(t: Trip, filter: string) {
+  const q = filter.toLowerCase();
+  return (
+    t.destination.toLowerCase().includes(q) ||
+    t.purpose.toLowerCase().includes(q) ||
+    (t.customer ?? "").toLowerCase().includes(q) ||
+    (t.project ?? "").toLowerCase().includes(q)
+  );
+}
+
 export default function App() {
   const [state, setState] = useState<AppState>(() => {
     const t = DemoSeed.trips[0];
@@ -161,14 +171,12 @@ export default function App() {
   const [sortKey, setSortKey] = useState<"start" | "dest">("start");
 
   const visibleTrips = useMemo(() => {
-    const f = state.trips.filter(
-      (t) =>
-        t.destination.toLowerCase().includes(filter.toLowerCase()) ||
-        t.purpose.toLowerCase().includes(filter.toLowerCase()) ||
-        t.customer.toLowerCase().includes(filter.toLowerCase()) ||
-        t.project.toLowerCase().includes(filter.toLowerCase())
+    const f = state.trips.filter((t) => matchesFilter(t, filter));
+    return [...f].sort((a, b) =>
+      sortKey === "start"
+        ? a.startDate.localeCompare(b.startDate)
+        : a.destination.localeCompare(b.destination)
     );
-    return [...f].sort((a, b) => (sortKey === "start" ? a.startDate.localeCompare(b.startDate) : a.destination.localeCompare(b.destination)));
   }, [state.trips, filter, sortKey]);
 
   function addTrip() {


### PR DESCRIPTION
## Summary
- Extract trip text filtering into a new `matchesFilter` helper that tolerates missing customer or project fields
- Use the helper when computing visible trips
- Add unit test ensuring `matchesFilter` doesn't fail when customer/project data is absent

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching @testing-library/react)*

------
https://chatgpt.com/codex/tasks/task_b_68b0bee2fa6c832daeb1e19e0a174404